### PR TITLE
adding function for getting selected residues

### DIFF
--- a/src/app/viewer.ts
+++ b/src/app/viewer.ts
@@ -61,7 +61,7 @@ import { PDBeViewport } from './ui/pdbe-viewport';
 import { PDBeViewportControls } from './ui/pdbe-viewport-controls';
 import { UIComponents } from './ui/split-ui/components';
 import { LayoutSpec, createPluginSplitUI, resolveHTMLElement } from './ui/split-ui/split-ui';
-
+import {Structure, StructureProperties } from "molstar/lib/mol-model/structure"
 
 export class PDBeMolstarPlugin {
 
@@ -593,6 +593,23 @@ export class PDBeMolstarPlugin {
      * `structureNumberOrId` is either index (numbered from 1!) or the ID that was provided when loading the structure. */
     getStructure(structureNumberOrId: number | string): StructureRef | undefined {
         return this.getStructures(structureNumberOrId)[0]?.structureRef;
+    }
+
+    getSelectedResidues(): { position: number, chain: string }[] {
+        const selections = Array.from(this.plugin.managers.structure.selection.entries.values());
+        const selectedResidues: { position: number, chain: string }[] = [];
+        for (const {structure} of selections) {
+
+            if (!structure) continue;
+            Structure.eachAtomicHierarchyElement(structure, {
+                residue: (loc) => {
+                  const position = StructureProperties.residue.label_seq_id(loc);
+                  const chain = StructureProperties.chain.auth_asym_id(loc);
+                    selectedResidues.push({ position, chain });
+                },
+              });
+        }
+        return selectedResidues;
     }
 
     /** Helper methods related to canvas and layout */


### PR DESCRIPTION
molstar does not make it as easy as it could be to get selection info in a way that's useful for molecular modeling tools. this PR adds a helper that can be called directly on the Viewer instance and return the currently selected residues and chain IDs.